### PR TITLE
test ereef

### DIFF
--- a/lib/bald/tests/integration/test_cdl.py
+++ b/lib/bald/tests/integration/test_cdl.py
@@ -8,18 +8,18 @@ import numpy as np
 import bald
 from bald.tests import BaldTestCase
 
+
 class Test(BaldTestCase):
     def setUp(self):
         self.cdl_path = os.path.join(os.path.dirname(__file__), 'CDL')
-        print(self.cdl_path)
-        
+
     def test_array_reference(self):
         with self.temp_filename('.nc') as tfile:
             cdl_file = os.path.join(self.cdl_path, 'array_reference.cdl')
             subprocess.check_call(['ncgen', '-o', tfile, cdl_file])
             validation = bald.validate_netcdf(tfile)
             exns = validation.exceptions()
-            self.assertTrue(validation.is_valid(), msg='{}  != []'.format(exns))
+            self.assertTrue(validation.is_valid(), msg='{} != []'.format(exns))
 
     def test_alias(self):
         with self.temp_filename('.nc') as tfile:
@@ -27,4 +27,16 @@ class Test(BaldTestCase):
             subprocess.check_call(['ncgen', '-o', tfile, cdl_file])
             validation = bald.validate_netcdf(tfile)
             exns = validation.exceptions()
-            self.assertTrue(validation.is_valid(), msg='{}  != []'.format(exns))
+            self.assertTrue(validation.is_valid(), msg='{} != []'.format(exns))
+
+    def test_ereef(self):
+        with self.temp_filename('.nc') as tfile:
+            cdl_file = os.path.join(self.cdl_path, 'ereefs-gbr4_ncld.cdl')
+            subprocess.check_call(['ncgen', '-o', tfile, cdl_file])
+            validation = bald.validate_netcdf(tfile)
+            exns = validation.exceptions()
+            self.assertTrue(validation.is_valid(), msg='{} != []'.format(exns))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Hi @jyucsiro 

I have added this CDL file to the tests in this PR.  I think it's a really important that all the CDL files in the repository are tested and validated.

The test currently fails, as follows:
```
======================================================================
FAIL: test_ereef (bald.tests.integration.test_cdl.Test)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/marky/coding/binary-array-ld/bald/lib/bald/tests/integration/test_cdl.py", line 38, in test_ereef
AssertionError: ['http://qudt.org/vocab/unit#Meter is not resolving as a resource (404).', 'http://qudt.org/vocab/unit#MeterPerSecond is not resolving as a resource (404).', 'http://qudt.org/vocab/unit#MeterPerSecond is not resolving as a resource (404).', 'http://qudt.org/vocab/unit#DegreeCelsius is not resolving as a resource (404).']  != []

----------------------------------------------------------------------

```
which I think shows the value of this testing approach

the tests are a bit slow to run: that will need some thought as we go on, but for now, I think it's manageable

please could you consider merging this change into your branch and then updating to `qudt` urls so that they resolve?
I think we should do that before we merge #13 onto master

cheers
mark
