### PR TITLE
Testing MDL process chain CDL file.

### DIFF
--- a/lib/bald/tests/integration/CDL/ProcessChain0200.cdl
+++ b/lib/bald/tests/integration/CDL/ProcessChain0200.cdl
@@ -1,0 +1,16 @@
+netcdf tmpcdltest {
+variables:
+        int gfsmos_process_chain;
+        gfsmos_process_chain:OM_Process = "(step1 step2)";
+
+int step1;
+        step1:LE_ProcessStep = "https://codes.nws.noaa.gov/NumericalWeatherPrediction/Models/GFS13" ;
+        step1:LE_Source = "https://codes.nws.noaa.gov/DataAssimilation/Methods/GDAS13" ;
+
+int step2;
+        step2:LE_ProcessStep = "https://codes.nws.noaa.gov/StatisticalPostProcessing/Methods/GFSMOS05" ;
+        step2:LE_Source = "https://codes.nws.noaa.gov/NumericalWeatherPrediction/Models/GFS13" ;
+
+//global attribute
+        :process_chain = "gfsmos_process_chain";
+}

--- a/lib/bald/tests/integration/test_cdl.py
+++ b/lib/bald/tests/integration/test_cdl.py
@@ -28,3 +28,11 @@ class Test(BaldTestCase):
             validation = bald.validate_netcdf(tfile)
             exns = validation.exceptions()
             self.assertTrue(validation.is_valid(), msg='{}  != []'.format(exns))
+            
+    def test_process_chain(self):
+        with self.temp_filename('.nc') as tfile:
+            cdl_file = os.path.join(self.cdl_path, 'ProcessChain0200.cdl')
+            subprocess.check_call(['ncgen', '-o', tfile, cdl_file])
+            validation = bald.validate_netcdf(tfile)
+            exns = validation.exceptions()
+            self.assertTrue(validation.is_valid(), msg='{}  != []'.format(exns))


### PR DESCRIPTION
The URLs do not resolve.  I think I know how to fix that, but it will take some time.  (If I don't, Mark will be conducting yet another class for us.)

I have three ISO references that may well be suitable for the alias technique.  I just didn't try it this time.  I'd create aliases for OM_ and LE_.  If we cannot find suitable web references for OM_ and LE_, we can define the strings and include appropriate DOIs in a doc block.

I also have four URLs that would benefit from an alias technique.  https://codes.nws.noaa.gov/ occurs in all four of them.