### PR TITLE
adding test case for ereefs

### DIFF
--- a/lib/bald/tests/integration/test_cdl_rdfgraph.py
+++ b/lib/bald/tests/integration/test_cdl_rdfgraph.py
@@ -36,3 +36,15 @@ class Test(BaldTestCase):
             with open(os.path.join(self.ttl_path, 'multi_array_reference.ttl'), 'r') as sf:
                 expected_ttl = sf.read()
             self.assertEqual(expected_ttl, ttl)
+
+    def test_ereefs(self):
+        with self.temp_filename('.nc') as tfile:
+            cdl_file = os.path.join(self.cdl_path, 'ereefs_gbr4_ncld.cdl')
+            subprocess.check_call(['ncgen', '-o', tfile, cdl_file])
+            root_container = bald.load_netcdf(tfile)
+            testPassed
+            try:
+               ttl = root_container.rdfgraph().serialize(format='n3').decode("utf-8")
+            except TypeError:
+               self.fail("Test case could not convert ereefs CDL to RDF")
+


### PR DESCRIPTION
This PR is from the current master... Tried to create an RDF graph for the eReefs CDL example using the bald library but received an error

Traceback (most recent call last):
File "nc2rdf.py", line 39, in 
cdl2rdf(args.ncfile, args.format)
File "nc2rdf.py", line 23, in cdl2rdf
nc2rdf(tfilename, outformat)
File "nc2rdf.py", line 13, in nc2rdf
ttl = root_container.rdfgraph().serialize(format=outformat).decode("utf-8")
File "/home/jon/miniconda2/envs/bald_py3/lib/python3.6/site-packages/bald/init.py", line 441, in rdfgraph
graph = self.rdfnode(graph)
File "/home/jon/miniconda2/envs/bald_py3/lib/python3.6/site-packages/bald/init.py", line 430, in rdfnode
graph = obj.rdfnode(graph)
File "/home/jon/miniconda2/envs/bald_py3/lib/python3.6/site-packages/bald/init.py", line 418, in rdfnode
objs = set([objs])
TypeError: unhashable type: 'numpy.ndarray'

Unsure why there is a typeError...